### PR TITLE
tree tools and industries

### DIFF
--- a/ts/Studio.ts
+++ b/ts/Studio.ts
@@ -361,6 +361,10 @@ export class Studio {
             onClick: () => void;
         }[] = [
             {
+                name: 'Fix trees (Then smart cut trees)',
+                onClick: () => this.map.getTreeUtil().cutFix().catch(handleError),
+            },
+            {
                 name: 'Cut All Trees (increases save file size)',
                 onClick: () => this.map.getTreeUtil().cutAll().catch(handleError),
             },
@@ -368,10 +372,10 @@ export class Studio {
                 name: 'Plant all trees (dangerous!)',
                 onClick: () => this.map.getTreeUtil().plantAll().catch(handleError),
             },
-            {
-                name: 'Smart plant trees',
-                onClick: () => this.map.getTreeUtil().smartPlant().catch(handleError),
-            },
+            // {
+            //    name: 'Smart plant trees',
+            //    onClick: () => this.map.getTreeUtil().smartPlant().catch(handleError),
+            // },
             {
                 name: 'Smart cut trees (preview)',
                 onClick: () => this.map.previewSmartPlant().catch(handleError),
@@ -695,7 +699,7 @@ export class Studio {
             resetFramePage();
         };
         const frameInCategory = (f: Frame, c: typeof frameCategories[number]) =>
-            isFrameType(f.type) && (frameDefinitions[f.type][c] ?? false);
+            isFrameType(f.type) && (frameDefinitions[f.type][c] || false);
         const labels = {
             engine: `Engines (${railroad.frames.filter((f) => frameInCategory(f, 'engine')).length})`,
             tender: `Tenders (${railroad.frames.filter((f) => frameInCategory(f, 'tender')).length})`,
@@ -1149,7 +1153,7 @@ export class Studio {
                     let c: string | undefined = undefined;
                     let tooltip: string = key;
                     if (value < minValue || value > maxValue) {
-                        c = 'table-warning';
+                        c = 'table-danger';
                         tooltip = `Expected ${key} to in range [${minValue}, ${maxValue}]`;
                     }
                     const options: InputTextOptions = {
@@ -1228,16 +1232,7 @@ export class Studio {
                     const limit = isCargoType(freightType) ? limits[freightType] ?? 0 : 0;
                     const max = String(limit);
                     const options: InputTextOptions = {min: '0', max};
-                    const form = editNumber(this, frame.state.freightAmount, options, setAmount);
-                    if (isCargoType(freightType) &&
-                        typeof limits[freightType] !== 'undefined' &&
-                        frame.state.freightAmount > limit) {
-                        const title = 'Too much freight';
-                        const c = 'table-warning';
-                        addStat('Freight Amount', form, title, c);
-                    } else {
-                        addStat('Freight Amount', form);
-                    }
+                    addStat('Freight Amount', editNumber(this, frame.state.freightAmount, options, setAmount));
                     const allowedCargo = Object.keys(limits) as CargoType[];
                     const setFreightType = (type: GvasString) => {
                         // TODO: Update freight amount limits
@@ -1286,7 +1281,6 @@ export class Studio {
             } else {
                 const setIndustryName = (name: GvasString) => industry.type = name;
                 td.replaceChildren(editString(this, industry.type, setIndustryName));
-                td.classList.add('table-warning');
             }
             tr.appendChild(td);
             // Inputs
@@ -1301,9 +1295,6 @@ export class Studio {
             ];
             const inputLabels = industryName ? industryInputLabels[industryName] ?? defaultLabelsI : defaultLabelsI;
             td.appendChild(editIndustryProducts(this, 'Input', inputLabels, industry.inputs, setIndustryInputs));
-            if (inputLabels === defaultLabelsI && !industry.inputs.every((v) => v === 0)) {
-                td.classList.add('table-warning');
-            }
             tr.appendChild(td);
             // Outputs
             td = document.createElement('td');
@@ -1316,9 +1307,6 @@ export class Studio {
             ];
             const outputLabels = industryName ? industryOutputLabels[industryName] ?? defaultLabelsO : defaultLabelsO;
             td.appendChild(editIndustryProducts(this, 'Output', outputLabels, industry.outputs, setIndustryOutputs));
-            if (outputLabels === defaultLabelsO && !industry.outputs.every((v) => v === 0)) {
-                td.classList.add('table-warning');
-            }
             tr.appendChild(td);
             // Location
             td = document.createElement('td');

--- a/ts/Studio.ts
+++ b/ts/Studio.ts
@@ -699,7 +699,7 @@ export class Studio {
             resetFramePage();
         };
         const frameInCategory = (f: Frame, c: typeof frameCategories[number]) =>
-            isFrameType(f.type) && (frameDefinitions[f.type][c] || false);
+            isFrameType(f.type) && (frameDefinitions[f.type][c] ?? false);
         const labels = {
             engine: `Engines (${railroad.frames.filter((f) => frameInCategory(f, 'engine')).length})`,
             tender: `Tenders (${railroad.frames.filter((f) => frameInCategory(f, 'tender')).length})`,

--- a/ts/TreeUtil.ts
+++ b/ts/TreeUtil.ts
@@ -1,4 +1,4 @@
-import {Industry, Railroad, Sandhouse, Spline, SplineTrack, Switch, Turntable, Watertower} from './Railroad';
+import {Industry, Railroad, Spline, SplineTrack, Switch, Turntable, Watertower} from './Railroad';
 import {Studio} from './Studio';
 import {Vector, vectorSum} from './Vector';
 import {VectorSet} from './VectorSet';
@@ -70,7 +70,11 @@ export class TreeUtil {
             });
         }
     }
-
+    async cutFix() {
+        this.railroad.removedVegetationAssets = [];
+        this.railroad.vegetation = [];
+        this.setMapModified();
+    }
     async cutAll() {
         const trees = await this.allTrees();
         const before = this.railroad.removedVegetationAssets.length;
@@ -84,6 +88,7 @@ export class TreeUtil {
         if (before === 0) return;
         const treesBefore = this.railroad.removedVegetationAssets;
         this.railroad.removedVegetationAssets = [];
+        this.railroad.vegetation = [];
         this.setMapModified();
         return this.onTreesChanged(before, 0, treesBefore);
     }
@@ -131,7 +136,6 @@ export class TreeUtil {
     treeFilter(tree: Vector) {
         return !spawnFilter(tree) && undefined === (
             this.railroad.industries.find((i) => industryFilter(i, tree)) ??
-            this.railroad.sandhouses.find((s) => sandhouseFilter(s, tree)) ??
             this.railroad.splines.find((s) => splineFilter(s, tree)) ??
             this.railroad.splineTracks.find((s) => splineTrackFilter(s, tree)) ??
             this.railroad.switches.find((s) => switchFilter(s, tree)) ??
@@ -209,6 +213,18 @@ function industryFilter(industry: Industry, tree: Vector): boolean {
             return radiusFilter(industry.location, tree, 35_00); // 35m
         case 'firewooddepot':
             return radiusFilter(industry.location, tree, 15_00); // 15m
+        case 'WaterWell':
+            return radiusFilter(industry.location, tree, 10_00); // 10m
+        case 'SandHouse':
+            return radiusFilter(industry.location, tree, 10_00); // 10m
+        case 'WheatFarm':
+            return radiusFilter(industry.location, tree, 41_00); // 41m
+        case 'MeatPackingPlant':
+            return radiusFilter(industry.location, tree, 36_00); // 36m
+        case 'CattleFarm':
+            return radiusFilter(industry.location, tree, 46_00); // 46m
+        case 'Woodrick':
+            return radiusFilter(industry.location, tree, 5_00); // 5m
         case 'enginehouse_alpine':
         case 'enginehouse_aspen':
         case 'enginehouse_barn':
@@ -249,10 +265,6 @@ function industryFilter(industry: Industry, tree: Vector): boolean {
             console.log(`Unknown industry type ${name}`);
             return false;
     }
-}
-
-function sandhouseFilter(sandhouse: Sandhouse, tree: Vector): boolean {
-    return radiusFilter(sandhouse.location, tree, 10_00); // 10m
 }
 
 function spawnFilter(tree: Vector): boolean {

--- a/ts/industries.ts
+++ b/ts/industries.ts
@@ -62,7 +62,7 @@ export const IndustryNames = [
     'MeatPackingPlant',
     'oilfield',
     'Refinery',
-    'Sandhouse',
+    'SandHouse',
     'sawmill',
     'smelter',
     'telegraphoffice',
@@ -124,6 +124,7 @@ export type IndustryName = typeof IndustryNames[number];
 export function getIndustryName(industry: Industry): IndustryName | null {
     if (typeof industry.type === 'number') return legacyIndustryNames[industry.type];
     if (isIndustryName(industry.type)) return industry.type;
+    console.warn(`Unrecognized industry ${industry.type}`);
     return null;
 }
 
@@ -147,7 +148,7 @@ export const industryNames: Record<IndustryName, string> = {
     'MeatPackingPlant': 'Meat Packing Plant',
     'oilfield': 'Oil Field',
     'Refinery': 'Refinery',
-    'Sandhouse': 'Sandhouse',
+    'SandHouse': 'Sand House',
     'sawmill': 'Sawmill',
     'smelter': 'Smelter',
     'telegraphoffice': 'Telegraph Office',
@@ -178,37 +179,36 @@ export const industryInputLabels: Partial<Record<IndustryName, FourStrings>> = {
     'Refinery': ['Crude Oil', 'Steel Pipes', 'Lumber', input4],
     'sawmill': ['Logs', input2, input3, input4],
     'smelter': ['Cordwood', 'Iron Ore', input3, input4],
+    'CattleFarm': ['Grain', 'Water', 'Straw Bale', input4],
     'WheatFarm': ['Seed Pallet', 'Water', input3, input4],
+    'MeatPackingPlant': ['Cattle', 'Coal', input2, input4],
 };
 
-const water: FourStrings = ['Water', output2, output3, output4];
 export const industryOutputLabels: Partial<Record<IndustryName, FourStrings>> = {
     'coalmine': ['Coal', output2, output3, output4],
-    'coaltower': ['Coal', output2, output3, output4],
-    'firewooddepot': ['Firewood', 'Firewood', 'Firewood', 'Firewood'],
-    'freightdepot': ['Seed Pallet', output2, output3, output4],
     'ironoremine': ['Iron Ore', output2, output3, output4],
     'ironworks': ['Steel Pipes', 'Tool Crates', output3, output4],
     'logcamp': ['Logs', 'Cordwood', output3, output4],
     'oilfield': ['Crude Oil', output2, output3, output4],
     'Refinery': ['Oil Barrel', output2, output3, output4],
-    'Sandhouse': ['Sand', output2, output3, output4],
+    'SandHouse': ['Sand', output2, output3, output4],
     'sawmill': ['Lumber', 'Beams', output3, output4],
     'smelter': ['Raw Iron', 'Rails', output3, output4],
-    'telegraphoffice': ['Unknown', output2, output3, output4],
-    'watertower_1870_style1': water,
-    'watertower_1870_style2': water,
-    'watertower_1870_style3': water,
-    'watertower_1870_style4': water,
-    'watertower_drgw': water,
-    'watertower_kanaskat_style1': water,
-    'watertower_kanaskat_style2': water,
-    'watertower_kanaskat_style3': water,
-    'watertower_kanaskat_style4': water,
-    'watertower_small': water,
-    'WaterWell': water,
+    'watertower_1870_style1': ['Water', output2, output3, output4],
+    'watertower_1870_style2': ['Water', output2, output3, output4],
+    'watertower_1870_style3': ['Water', output2, output3, output4],
+    'watertower_1870_style4': ['Water', output2, output3, output4],
+    'watertower_drgw': ['Water', output2, output3, output4],
+    'watertower_kanaskat_style1': ['Water', output2, output3, output4],
+    'watertower_kanaskat_style2': ['Water', output2, output3, output4],
+    'watertower_kanaskat_style3': ['Water', output2, output3, output4],
+    'watertower_kanaskat_style4': ['Water', output2, output3, output4],
+    'watertower_small': ['Water', output2, output3, output4],
+    'Woodrick': ['Firewood', output2, output3, output4],
+    'CattleFarm': ['Cattle', 'Cattle', output3, output4],
+    'WaterWell': ['Water', output2, output3, output4],
     'WheatFarm': ['Grain', 'Straw Bale', output3, output4],
-    'Woodrick': ['Firewood', 'Firewood', output3, output4],
+    'MeatPackingPlant': ['Meat', output2, output3, output4],
 };
 
 export const gizmoSvgPaths = {
@@ -381,6 +381,7 @@ export const industrySvgPaths: Partial<Record<IndustryName, Record<string, PathA
     'telegraphoffice': {
         'building': rect(-200, -150, 400, 300),
     },
+    'watertower_small': waterTower,
     'watertower_1870_style1': waterTower,
     'watertower_1870_style2': waterTower,
     'watertower_1870_style3': waterTower,
@@ -390,8 +391,6 @@ export const industrySvgPaths: Partial<Record<IndustryName, Record<string, PathA
     'watertower_kanaskat_style2': waterTower,
     'watertower_kanaskat_style3': waterTower,
     'watertower_kanaskat_style4': waterTower,
-    'watertower_small': waterTower,
-    'WaterWell': waterTower,
     'engineshed_style1': largeEngineHouse,
     'engineshed_style2': largeEngineHouse,
     'engineshed_style3': largeEngineHouse,
@@ -399,4 +398,11 @@ export const industrySvgPaths: Partial<Record<IndustryName, Record<string, PathA
     'Woodrick': {
         'building': rect(-130, -65, 260, 130),
     },
+    // ['M', 2800, 980],
+    // ['C', 2010, 640, 1600, 500, 1180, 420],
+    // ['S', 580, 500, -270, 1100],
+    // 'WheatFarm': {
+    // 'building': [
+    // ] as PathCommand[],
+    // },
 };


### PR DESCRIPTION
1. Added radiuses for new industries, so smart cut would work

2. Commented off replant trees 

 * Because if the game overwrite a save what has had the cut all trees treatment then later plant all trees won't work, so i put a bandaid on it for now
3. Added a fix button what basically is a replant all trees button, after pressing that smart cut can be used on maps what have been bugged
4. Added input and output names to industries
5.  the check wanted me to change this `isFrameType(f.type) && (frameDefinitions[f.type][c] || false);` in studio.ts to have ?? instead of || hope its fine