### PR TITLE
Fix pond z-order

### DIFF
--- a/ts/Railroad.ts
+++ b/ts/Railroad.ts
@@ -21,7 +21,6 @@ export interface Railroad {
     sandhouses: Sandhouse[];
     saveGame: {
         date: GvasString;
-        serverOwner: number | undefined;
         uniqueId: GvasString;
         uniqueWorldId: GvasString;
         version: GvasString;
@@ -32,11 +31,12 @@ export interface Railroad {
         dayLength: number | undefined;
         gameLevelName: GvasString;
         nightLength: number | undefined;
+        serverOwnerPlayerIndex: number | undefined;
         timeOfDay: number | bigint | undefined;
-        weatherType: number | undefined;
         weatherChangeIntervalMax: number | undefined;
         weatherChangeIntervalMin: number | undefined;
         weatherTransitionTime: number | undefined;
+        weatherType: number | undefined;
     };
     splineTracks: SplineTrack[];
     splines: Spline[];

--- a/ts/exporter.ts
+++ b/ts/exporter.ts
@@ -418,8 +418,8 @@ export function railroadToGvas(railroad: Railroad): Gvas {
                 strings[propertyName] = railroad.saveGame.version;
                 break;
             case 'serverownerplayerindex':
-                if (typeof railroad.saveGame.serverOwner !== 'undefined') {
-                    ints[propertyName] = railroad.saveGame.serverOwner;
+                if (typeof railroad.settings.serverOwnerPlayerIndex !== 'undefined') {
+                    ints[propertyName] = railroad.settings.serverOwnerPlayerIndex;
                 }
                 break;
             case 'smokestacktypearray':

--- a/ts/importer.ts
+++ b/ts/importer.ts
@@ -55,10 +55,8 @@ export function gvasToRailroad(gvas: Gvas): Railroad {
     const saveGameDate = optionalMap(gvas.strings, 'SaveGameDate');
     const saveGameUniqueID = optionalMap(gvas.strings, 'SaveGameUniqueID');
     const saveGameUniqueWorldID = optionalMap(gvas.strings, 'SaveGameUniqueWorldID');
-    const serverOwnerPlayerIndex = optionalMap(gvas.ints, 'ServerOwnerPlayerIndex') ?? undefined;
     const saveGame = {
         date: saveGameDate,
-        serverOwner: serverOwnerPlayerIndex,
         uniqueId: saveGameUniqueID,
         uniqueWorldId: saveGameUniqueWorldID,
         version: saveGameVersion,
@@ -69,12 +67,12 @@ export function gvasToRailroad(gvas: Gvas): Railroad {
     const dayLength = optionalMap(gvas.floats, 'DayLength') ?? undefined;
     const gameLevelName = optionalMap(gvas.strings, 'GameLevelName');
     const nightLength = optionalMap(gvas.floats, 'NightLength') ?? undefined;
+    const serverOwnerPlayerIndex = optionalMap(gvas.ints, 'ServerOwnerPlayerIndex') ?? undefined;
     const timeOfDay =
         (isNovemberUpdate ?
             optionalMap(gvas.dateTimes, 'TimeOfDay') :
             optionalMap(gvas.floats, 'TimeOfDay')
         ) ?? undefined;
-
     const weatherChangeIntervalMax = optionalMap(gvas.floats, 'WeatherChangeIntervalMax') ?? undefined;
     const weatherChangeIntervalMin = optionalMap(gvas.floats, 'WeatherChangeIntervalMin') ?? undefined;
     const weatherTransitionTime = optionalMap(gvas.floats, 'WeatherTransitionTime') ?? undefined;
@@ -85,6 +83,7 @@ export function gvasToRailroad(gvas: Gvas): Railroad {
         dayLength,
         gameLevelName,
         nightLength,
+        serverOwnerPlayerIndex,
         timeOfDay,
         weatherChangeIntervalMax,
         weatherChangeIntervalMin,

--- a/ts/industries.ts
+++ b/ts/industries.ts
@@ -471,6 +471,18 @@ export const industrySvgPaths: Partial<Record<IndustryName, Record<string, PathA
         'building': rect(-270, -670, 550, 850),
     },
     'Sawmill': {
+        'pond': [
+            ['M', 2800, 980],
+            ['C', 2010, 640, 1600, 500, 1180, 420],
+            ['S', 580, 500, -270, 1100],
+            ['S', -800, 1420, -1280, 2270],
+            ['S', -1330, 3170, -980, 4170],
+            ['S', -320, 4910, 570, 5220],
+            ['S', 1250, 5940, 2100, 5840],
+            ['S', 2640, 5310, 2750, 4360],
+            ['Z'],
+        ] as PathCommand[],
+        // eslint-disable-next-line sort-keys
         'building': combine(
             polyRect(-1000, -2800,
                 900, -2600,
@@ -487,17 +499,6 @@ export const industrySvgPaths: Partial<Record<IndustryName, Record<string, PathA
             rect(-3900, -4000, 300, 4500),
             rect(2600, 600, 300, 4200),
         ),
-        'pond': [
-            ['M', 2800, 980],
-            ['C', 2010, 640, 1600, 500, 1180, 420],
-            ['S', 580, 500, -270, 1100],
-            ['S', -800, 1420, -1280, 2270],
-            ['S', -1330, 3170, -980, 4170],
-            ['S', -320, 4910, 570, 5220],
-            ['S', 1250, 5940, 2100, 5840],
-            ['S', 2640, 5310, 2750, 4360],
-            ['Z'],
-        ] as PathCommand[],
     },
     'smelter': {
         'building': polyRectRel(-550, -4000,


### PR DESCRIPTION
* Fix issue where the pond was rendering above the platform and building.
* Move `serverOwnerPlayerIndex` to `settings`.