### PR TITLE
release: Use AWS CLI checksums

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,6 +26,5 @@ jobs:
       - run: npm ci
       - run: npm run check
       - run: npx webpack --mode=production
-      - run: aws s3 rm s3://railroad.studio/ --recursive --exclude '*' --include '*.js'
-      - run: aws s3 sync railroad.studio s3://railroad.studio --size-only
+      - run: aws s3 sync railroad.studio s3://railroad.studio
       - run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_ID }} --paths '/*'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,5 +26,5 @@ jobs:
       - run: npm ci
       - run: npm run check
       - run: npx webpack --mode=production
-      - run: aws s3 sync railroad.studio s3://railroad.studio
+      - run: aws s3 sync railroad.studio s3://railroad.studio --delete
       - run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_ID }} --paths '/*'

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
         "start": "webpack server --mode=development",
         "check": "npx prettier -c . && npx eslint .",
         "format": "npx prettier -w . && npx eslint . --fix",
-        "build:prod": "webpack --mode=production",
-        "sync": "aws s3 sync railroad.studio s3://railroad.studio"
+        "build:prod": "webpack --mode=production"
     },
     "devDependencies": {
         "@eslint/js": "^9.21.0",


### PR DESCRIPTION
Objects in the bucket that have been modified since December already have a CRC64NVME checksum, the new default for `aws s3` cli operations. Take advantage of the new behavior by removing the workarounds in the release process. This may cause the first release to overwrite bucket contents which are missing the checksum, which is why `--size-only` was in use.

https://github.com/aws/aws-cli/issues/6750

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Optimized the deployment process by consolidating file synchronization and cleanup steps to automatically remove outdated files during updates.
  - Removed an outdated synchronization task from the build configuration, streamlining deployments and contributing to a more efficient, reliable update workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->